### PR TITLE
Modified metadata handling from pelicanconf and microblog post, adds 2 new config variables 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,9 +167,12 @@ on `GitHub
 
 .. use the ".. data::" directive here for Sphinx output, but on GitHub, that just causes everything to disappear
 
+MICROBLOG_APPEND_HASHTAGS = True
+   Tags gets appended towards the end of a micro blog post as hashtags tags
+   by default.
 MICROBLOG_CATEGORY = "µ"
-   Default category for your micro blog posts. It could be overriden by the metadata
-   on top of individual posts.
+   Default category for your micro blog posts. It could be overriden by the
+   metadata on top of individual posts.
 MICROBLOG_FOLDER = "micro"
    Folder containing your micro blog posts, relative to your content root
    folder.

--- a/README.rst
+++ b/README.rst
@@ -146,27 +146,30 @@ If a value is given below, this represents the effective default value. If no
 value is given, the effective default value is ``None``.
 
 *Microblogging* also auto-configures itself when possible.  If you need to
-manually create the default configuration, you would need the following: 
+manually create the default configuration, you would need the following:
 
-.. code-block:: python 
+.. code-block:: python
 
-   # pelicanconf.py 
+   # pelicanconf.py
 
-   # if PLUGINS is not defined on Pelican 4.5+, these plugins will autoload 
-   PLUGINS = [ 
-       "minchin.pelican.readers.microblog", 
-       # others, as desired... 
-   ] 
+   # if PLUGINS is not defined on Pelican 4.5+, these plugins will autoload
+   PLUGINS = [
+       "minchin.pelican.readers.microblog",
+       # others, as desired...
+   ]
 
-   # the rest of the your configuration file... 
+   # the rest of the your configuration file...
 
 This documentation has to be manually updated. If the settings no longer match
 the plugin's behavior, or a setting is missing from here, please open a ticket
 on `GitHub
-<https://github.com/MinchinWeb/minchin.pelican.readers.microblog/issues>`_. 
+<https://github.com/MinchinWeb/minchin.pelican.readers.microblog/issues>`_.
 
 .. use the ".. data::" directive here for Sphinx output, but on GitHub, that just causes everything to disappear
 
+MICROBLOG_CATEGORY = "µ"
+   Default category for your micro blog posts. It could be overriden by the metadata
+   on top of individual posts.
 MICROBLOG_FOLDER = "micro"
    Folder containing your micro blog posts, relative to your content root
    folder.

--- a/minchin/pelican/readers/microblog/generator.py
+++ b/minchin/pelican/readers/microblog/generator.py
@@ -104,6 +104,11 @@ def addMicroArticle(articleGenerator):
 
         # print(post_len)
 
+        # NOTE:
+        # new_article_metadata is set by pelicanconf.py
+        # metadata is set from the microblog post and is given higher precedence below.
+        new_article_metadata.update(metadata)
+
         new_article = Article(
             content,
             new_article_metadata,

--- a/minchin/pelican/readers/microblog/generator.py
+++ b/minchin/pelican/readers/microblog/generator.py
@@ -6,7 +6,7 @@ from markupsafe import Markup
 
 from pelican.contents import Article
 from pelican.readers import MarkdownReader  # BaseReader
-from pelican.utils import get_date, pelican_open
+# from pelican.utils import get_date, pelican_open
 
 from .constants import LOG_PREFIX
 

--- a/minchin/pelican/readers/microblog/generator.py
+++ b/minchin/pelican/readers/microblog/generator.py
@@ -38,7 +38,10 @@ def addMicroArticle(articleGenerator):
         content, metadata = myMarkdownReader.read(source_path=post)
 
         new_article_metadata = {
-            "category": myBaseReader.process_metadata("category", "µ"),
+            "category": myBaseReader.process_metadata(
+                "category",
+                settings.get("MICROBLOG_CATEGORY", "µ"),
+            ),
             # "tags": myBaseReader.process_metadata("tags", "tagA, tagB"),
             "micro": myBaseReader.process_metadata("micro", True),
         }

--- a/minchin/pelican/readers/microblog/generator.py
+++ b/minchin/pelican/readers/microblog/generator.py
@@ -49,6 +49,9 @@ def addMicroArticle(articleGenerator):
         post_slug = settings["MICROBLOG_SLUG"].format(**metadata)
         metadata["slug"] = post_slug
 
+        new_article_metadata["author"] = myBaseReader.process_metadata(
+            "author", settings["AUTHOR"]
+        )
         new_article_metadata["title"] = myBaseReader.process_metadata(
             "title", post_slug
         )

--- a/minchin/pelican/readers/microblog/generator.py
+++ b/minchin/pelican/readers/microblog/generator.py
@@ -77,17 +77,18 @@ def addMicroArticle(articleGenerator):
 
             content = content.removesuffix("</p>") + " " + image_link + "</p>"
 
-        if "tags" in metadata.keys():
-            # new_article_metadata["tags"] = myBaseReader.process_metadata("tags", metadata["tags"])
-            new_article_metadata["tags"] = metadata["tags"]
+        if settings.get("MICROBLOG_APPEND_HASHTAGS", True):
+            if "tags" in metadata.keys():
+                # new_article_metadata["tags"] = myBaseReader.process_metadata("tags", metadata["tags"])
+                new_article_metadata["tags"] = metadata["tags"]
 
-            # metadata["tags"] is already a list of `pelican.urlwrappers.Tag`
-            for tag in metadata["tags"]:
-                tag_url = settings["SITEURL"] + "/" + tag.url
+                # metadata["tags"] is already a list of `pelican.urlwrappers.Tag`
+                for tag in metadata["tags"]:
+                    tag_url = settings["SITEURL"] + "/" + tag.url
 
-                tag_link = f'<a href="{tag_url}">#{tag.name}</a>'
+                    tag_link = f'<a href="{tag_url}">#{tag.name}</a>'
 
-                content = content.removesuffix("</p>") + " " + tag_link + "</p>"
+                    content = content.removesuffix("</p>") + " " + tag_link + "</p>"
 
         # warn if too long
         safe_content = Markup(content).striptags()

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ setuptools.setup(
     packages=PACKAGES,
     package_data={"": ["README.rst", "CHANGELOG.rst", "LICENSE.txt"]},
     include_package_data=True,
-    python_requires='> 3.9',
+    python_requires='>= 3.9',
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRA_REQUIRES,
     platforms="any",


### PR DESCRIPTION
- **Allow for Python 3.9**
- **Add MICROBLOG_CATEGORY configuration variable**
- **Allow overriding configured microblog metadata from a post**
- **Ensure default author if not mentioned in micro blog**
- **Comment out unused imports**
- **Add MICROBLOG_APPEND_HASHTAGS configuration variable**
